### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,8 @@ Installation
 ---------------
 
 ### Installation (via composer)
-```js
-{
-    "require": {
-        "winzou/state-machine-bundle": "~0.1"
-    }
-}
+```sh
+composer require winzou/state-machine-bundle
 ```
 
 ### Register the bundle


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
