### PR TITLE
Allow to do callbacks on "object" && set status when callback(s) (before) fails

### DIFF
--- a/Callback/ContainerAwareCallback.php
+++ b/Callback/ContainerAwareCallback.php
@@ -42,6 +42,12 @@ class ContainerAwareCallback extends Callback
             && $this->container->has($serviceId = substr($this->callable[0], 1))
         ) {
             $this->callable[0] = $this->container->get($serviceId);
+        } elseif (
+            is_array($this->callable)
+            && is_string($this->callable[0])
+            && 0 === strpos($this->callable[0], 'object')
+        ) {
+            $this->callable[0] = $event->getStateMachine()->getObject();
         }
 
         return parent::call($event);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('class')->isRequired()->end()
             ->scalarNode('graph')->defaultValue('default')->end()
             ->scalarNode('property_path')->defaultValue('state')->end()
+            ->scalarNode('ignore_before_callback_result')->defaultValue(true)->end()
             ->scalarNode('state_machine_class')->defaultValue('SM\\StateMachine\\StateMachine')->end()
         ;
 
@@ -74,6 +75,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->scalarNode('to')->end()
+                        ->scalarNode('on_fail')->defaultValue(false)->end()
                     ->end()
                 ->end()
             ->end()

--- a/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
+++ b/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
@@ -5,6 +5,7 @@ namespace spec\winzou\Bundle\StateMachineBundle\Callback;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SM\Event\TransitionEvent;
+use SM\StateMachine\StateMachine;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ContainerAwareCallbackSpec extends ObjectBehavior
@@ -43,5 +44,27 @@ class ContainerAwareCallbackSpec extends ObjectBehavior
         $service->dummy($event)->shouldBeCalled()->willReturn(true);
 
         $this->call($event)->shouldReturn(true);
+    }
+
+    function it_use_object_class_to_do_the_callback(
+        $container,
+        TransitionEvent $event,
+        StateMachine $sm
+    ) {
+        $object = new Dummy();
+        $this->beConstructedWith(array(), array('object', 'methodToBeCalled'), $container);
+
+        $event->getStateMachine()->willReturn($sm);
+        $sm->getObject()->willReturn($object);
+
+        $this->call($event)->shouldReturn(true);
+    }
+}
+
+class Dummy
+{
+    public function methodToBeCalled()
+    {
+        return true;
     }
 }


### PR DESCRIPTION
BC: true
Tests: true

Allow to do callbacks in the "object"
----------

Allow to set a state when the transition(s) fail(s) [when callback(s) (before) fails]
ignore_before_callback_result
on_fail

this PR should only be merged after this PR other way is useless
https://github.com/winzou/state-machine/pull/11