### PR TITLE
Container exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
     only:
         - master
 
+dist: xenial
 language: php
 
 php:
@@ -10,9 +11,31 @@ php:
     - 5.5
     - 5.6
     - hhvm
+    - 7.0
+    - 7.1
+    - 7.2
+
+env:
+   - SYMFONY_VERSION=~2.1
+   - SYMFONY_VERSION=~3.0
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3
+      dist: precise
+  allow_failures:
+    - php: 5.3
+      dist: xenial
+    - php: 5.3
+      env: 'SYMFONY_VERSION=~3.0'
+    - php: 5.4
+      env: 'SYMFONY_VERSION=~3.0'
 
 before_script:
-    - composer --no-interaction --prefer-source install
+    - composer self-update
+    - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update --dev
+    - composer install --no-interaction --prefer-source --no-suggest
 
 script:
     - bin/phpspec run -f dot

--- a/Callback/ContainerAwareCallback.php
+++ b/Callback/ContainerAwareCallback.php
@@ -39,8 +39,9 @@ class ContainerAwareCallback extends Callback
             is_array($this->callable)
             && is_string($this->callable[0])
             && 0 === strpos($this->callable[0], '@')
-            && $this->container->has($serviceId = substr($this->callable[0], 1))
         ) {
+
+            $serviceId = substr($this->callable[0], 1);
             $this->callable[0] = $this->container->get($serviceId);
         }
 

--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ winzou_state_machine:
             guard:
                 guard_on_submitting:
                     on:   'submit_changes'                        # call the callback on a specific transition
-                    do:   [@my.awesome.service, 'isSubmittable']  # will call the method of this Symfony service
+                    do:   ['@my.awesome.service', 'isSubmittable']  # will call the method of this Symfony service
                     args: ['object']                              # arguments for the callback
             # will be called before applying a transition
             before:
                 update_reviewer:
                     on:   'create'
-                    do:   [@my.awesome.service, 'update']
+                    do:   ['@my.awesome.service', 'update']
                     args: ['object']
             # will be called after applying a transition
             after:
                 email_on_publish:
                     on:   'publish'
-                    do:   [@my.awesome.service, 'sendEmail']
+                    do:   ['@my.awesome.service', 'sendEmail']
                     args: ['object', '"Email title"']
 ```
 

--- a/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
+++ b/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
@@ -6,6 +6,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SM\Event\TransitionEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class ContainerAwareCallbackSpec extends ObjectBehavior
 {
@@ -23,12 +24,20 @@ class ContainerAwareCallbackSpec extends ObjectBehavior
     {
         $this->beConstructedWith(array(), array('@my_service', 'dummy'), $container);
 
-        $container->has('my_service')->shouldBeCalled()->willReturn(true);
         $container->get('my_service')->shouldBeCalled()->willReturn($service);
 
         $service->dummy($event)->shouldBeCalled()->willReturn(true);
 
         $this->call($event)->shouldReturn(true);
+    }
+
+    function it_throws_an_exception_when_relevant($container, TransitionEvent $event, ContainerAwareCallbackSpec $service)
+    {
+        $this->beConstructedWith(array(), array('@my_service', 'dummy'), $container);
+
+        $container->get('my_service')->shouldBeCalled()->willThrow('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
+
+        $this->shouldThrow('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException')->during('call', array($event));
     }
 
     function dummy()


### PR DESCRIPTION
Hello there,

I've figured out a PHP warning can be issued when trying to access a private service during callbacks.

```yaml
# app/config/config.yml
services:

    AppBundle\Services\DummyService:
        class: AppBundle\Services\DummyService

winzou_state_machine:
    my_bundle_article:
        class: AppBundle\Entity\Article
        property_path: state
        graph: simple
        states:
            - pending_review
            - awaiting_changes
        transitions:
            submit_changes:
                from: [awaiting_changes]
                to: pending_review
        callbacks:
            guard:
                guard_on_submitting:
                    on:   'submit_changes'
                    do:   ['@AppBundle\Services\DummyService', 'isSubmittable']
                    args: ['object']
```
Everything should work fine, right?
The problem is, since Symfony 3.3 services are private by default. When debugging:
```bash
php bin/console debug:container "AppBundle\Services\DummyService"
```
No error will be thrown, since this service exists, but when hitting the `guard_on_submitting` callback, the following PHP error will be raised:

> warning: call_user_func_array() expects parameter 1 to be a valid callback, class '@AppBundle\Services\DummyService' not found

This is because the resolver relies on `ContainerInterface::has()`, which returns false when trying to access a private service. Then I think that when the 1st argument of a callback starts with `@`, it's obviously a service (that's how Symfony works), then we should necessarily expect the container to return it, otherwise it's its responsibility to throw a `ServiceNotFoundException`, preventing to resolve the callback.

With this PR, the PHP warning is now a `ServiceNotFoundException` thrown instead:
> You have requested a non-existent service "AppBundle\Services\DummyService".