### PR TITLE
Symfony 4 / Flex compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
 env:
    - SYMFONY_VERSION=~2.1
    - SYMFONY_VERSION=~3.0
+   - SYMFONY_VERSION=~4.0
 
 matrix:
   fast_finish: true
@@ -31,6 +32,20 @@ matrix:
       env: 'SYMFONY_VERSION=~3.0'
     - php: 5.4
       env: 'SYMFONY_VERSION=~3.0'
+    - php: 5.3
+      env: 'SYMFONY_VERSION=~4.0'
+    - php: 5.4
+      env: 'SYMFONY_VERSION=~4.0'
+    - php: 5.5
+      env: 'SYMFONY_VERSION=~4.0'
+    - php: 5.6
+      env: 'SYMFONY_VERSION=~4.0'
+    - php: 7.0
+      env: 'SYMFONY_VERSION=~4.0'
+    - php: hhvm
+      env: 'SYMFONY_VERSION=~4.0'
+    - php: hhvm
+      dist: xenial
 
 before_script:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php":                      ">5.3.0",
-        "symfony/framework-bundle": "~2.1|~3.0",
-        "winzou/state-machine":     "~0.3"
+        "winzou/state-machine":     "~0.3",
+        "symfony/framework-bundle": "~2.1|~3.0|^4.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0"


### PR DESCRIPTION
Hello there,

I have brought this bundle Symfony 4.0+ and Flex compatibility.

Since `symfony/skeleton`conflicts with `symfony/symfony` (new Symfony 4.0+ policy is to avoid using the whole framework), I have moved Symfony requirement into `require-dev`.

For the bundle to comply with composer requirements, winzou/state-machine#37 needs to be merged (and tagged) first.

I have modified `.travis.yml`as well.

Can you please tag a new minor version?

Thank you,
Ben