### PR TITLE
Fix debug command when callback on is not defined or is string

### DIFF
--- a/Command/winzouStateMachineDebugCommand.php
+++ b/Command/winzouStateMachineDebugCommand.php
@@ -146,7 +146,14 @@ class winzouStateMachineDebugCommand extends ContainerAwareCommand
             reset($callbacks);
 
             foreach ($callbacks as $name => $callback) {
-                $table->addRow(array($name, implode("\n", $callback['on']), implode("\n", $callback['do']), implode("\n", $callback['args'])));
+                if (empty($callback['on'])) {
+                    $callbackOn = array('*');
+                } elseif(is_array($callback['on'])) {
+                    $callbackOn = $callback['on'];
+                } else {
+                    $callbackOn = array($callback['on']);
+                }
+                $table->addRow(array($name, implode("\n", $callbackOn), implode("\n", $callback['do']), implode("\n", $callback['args'])));
 
                 if ($name !== $lastCallback) {
                     $table->addRow(new TableSeparator());


### PR DESCRIPTION
It fixes the notice exception when $callback['on'] is not defined because you can choose to fire the callback for all transitions.
It also fixes the #47 issue