### PR TITLE
use psr container interface instead of symfony container interface

### DIFF
--- a/Callback/ContainerAwareCallback.php
+++ b/Callback/ContainerAwareCallback.php
@@ -13,7 +13,7 @@ namespace winzou\Bundle\StateMachineBundle\Callback;
 
 use SM\Callback\Callback;
 use SM\Event\TransitionEvent;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class ContainerAwareCallback extends Callback
 {

--- a/Callback/ContainerAwareCallbackFactory.php
+++ b/Callback/ContainerAwareCallbackFactory.php
@@ -14,7 +14,7 @@ namespace winzou\Bundle\StateMachineBundle\Callback;
 use SM\SMException;
 use SM\Callback\CallbackFactory;
 use SM\Callback\CallbackInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class ContainerAwareCallbackFactory extends CallbackFactory
 {

--- a/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
+++ b/spec/winzou/Bundle/StateMachineBundle/Callback/ContainerAwareCallbackSpec.php
@@ -4,7 +4,7 @@ namespace spec\winzou\Bundle\StateMachineBundle\Callback;
 
 use PhpSpec\ObjectBehavior;
 use SM\Event\TransitionEvent;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use winzou\Bundle\StateMachineBundle\Callback\ContainerAwareCallback;
 


### PR DESCRIPTION
Replacing symfony container interface against psr interface to remove deprecations.

`Since symfony/dependency-injection 5.1: The "Symfony\Component\DependencyInjection\ContainerInterface" autowiring alias is deprecated. `