### PR TITLE
Fix debug command for Symfony 7

### DIFF
--- a/Command/winzouStateMachineDebugCommand.php
+++ b/Command/winzouStateMachineDebugCommand.php
@@ -76,7 +76,7 @@ class winzouStateMachineDebugCommand extends Command
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $key = $input->getArgument('key');
 

--- a/Command/winzouStateMachineDebugCommand.php
+++ b/Command/winzouStateMachineDebugCommand.php
@@ -2,6 +2,7 @@
 
 namespace winzou\Bundle\StateMachineBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputArgument;
@@ -10,6 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 
+#[AsCommand('debug:winzou:state-machine')]
 class winzouStateMachineDebugCommand extends Command
 {
     protected static $defaultName = 'debug:winzou:state-machine';


### PR DESCRIPTION
![Capture d’écran de 2024-04-22 15-27-01](https://github.com/winzou/StateMachineBundle/assets/8329789/53960c16-a2af-4852-8b4e-11771ac825ce)

On SF7, we need to fix the default name too:
https://github.com/symfony/symfony/blob/7.0/src/Symfony/Component/Console/Command/Command.php#L57